### PR TITLE
feat: API 버전 관리를 위한 컨트롤러 basepath 어노테이션 추가(sir/f/common)

### DIFF
--- a/src/main/java/com/bside/sidefriends/common/annotation/SideFriendsController.java
+++ b/src/main/java/com/bside/sidefriends/common/annotation/SideFriendsController.java
@@ -1,0 +1,16 @@
+package com.bside.sidefriends.common.annotation;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@RestController
+@RequestMapping("/api/v1/*")
+public @interface SideFriendsController {
+}


### PR DESCRIPTION
### PR 목적
- 기능 추가

### PR 내용 요약
- request url mapping 시 basepath에 들어갈 API 버전 어노테이션 추가
- 컨트롤러에 `@SideFriendsController` 어노테이션 추가 시, `/api/v1` 설정하지 않아도 됨
- api 버전 변경으로 인해 basepath API 버전 변경 시, `@SideFriendsController` 어노테이션에서 관리
