### PR TITLE
fix: username 필드 저장되지 않는 오류 수정

### DIFF
--- a/src/main/java/com/bside/sidefriends/users/service/UserServiceImpl.java
+++ b/src/main/java/com/bside/sidefriends/users/service/UserServiceImpl.java
@@ -27,13 +27,12 @@ public class UserServiceImpl implements UserService {
         }
 
         User userEntity = User.builder()
-                .username(userCreateRequestDto.getProvider() + "_" + userCreateRequestDto.getProviderId())
                 .name(userCreateRequestDto.getName())
                 .email(userCreateRequestDto.getEmail())
                 .role(User.Role.ROLE_USER) // 회원 가입 시 회원 권한 기본값 ROLE_USER
-                .username(userCreateRequestDto.getUsername())
                 .provider(userCreateRequestDto.getProvider())
                 .providerId(userCreateRequestDto.getProviderId())
+                .username(userCreateRequestDto.getProvider() + "_" + userCreateRequestDto.getProviderId())
                 .isDeleted(false) // 회원 가입 시 회원 삭제 여부 false
                 .build();
 


### PR DESCRIPTION
### PR 목적
- 버그 수정

### PR 내용 요약
- `UserServiceImpl`에서 회원가입 시 유저 엔티티 빌드할 때 `username` 필드를 중복 지정한 오류 해결