### PR TITLE
feat: 응답 객체 생성 공통 클래스 및 메서드 구현(sir/f/common)

### DIFF
--- a/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
+++ b/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
@@ -1,5 +1,8 @@
 package com.bside.sidefriends.common.response;
 
+import lombok.Getter;
+
+@Getter
 public enum ResponseCode {
 
     // 로그인(101-150)

--- a/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
+++ b/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
@@ -23,6 +23,11 @@ public enum ResponseCode {
 
     ;
 
-    private String code;
-    private String message;
+    private final String code;
+    private final String message;
+
+    ResponseCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
 }

--- a/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
+++ b/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
@@ -1,0 +1,25 @@
+package com.bside.sidefriends.common.response;
+
+public enum ResponseCode {
+
+    // 로그인(101-150)
+
+    // 회원(151-199)
+
+    // 반려동물(201-299)
+
+    // 퀵 기록(301-399)
+
+    // 체크리스트(401-450)
+
+    // 할 일, 스케쥴(451-499)
+
+    // 양육일지(501-599)
+
+    // 가족 그룹(601-699)
+
+    ;
+
+    private String code;
+    private String message;
+}

--- a/src/main/java/com/bside/sidefriends/common/response/ResponseDto.java
+++ b/src/main/java/com/bside/sidefriends/common/response/ResponseDto.java
@@ -1,10 +1,7 @@
 package com.bside.sidefriends.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -16,25 +13,47 @@ public class ResponseDto<T> {
     private String message;
     private T data;
 
+    private ResponseDto(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
     /**
-     * 성공 응답 객체 반환 메서드
-     * @param code {@link ResponseCode}의 응답 코드
-     * @param message {@link ResponseCode}의 응답 메시지
+     * 성공 응답 객체 생성
+     * @param responseCode {@link ResponseCode} 응답 코드 및 메시지
+     * @return 성공 응답 DTO 객체
+     */
+    public static ResponseDto<ResponseCode> onSuccessWithoutData(ResponseCode responseCode) {
+        return new ResponseDto<>(responseCode.getCode(), responseCode.getMessage());
+    }
+
+    /**
+     * 성공 응답 객체 생성
+     * @param responseCode {@link ResponseCode} 응답 코드 및 메시지
      * @param data 성공 응답에서 반환할 데이터
      * @return 성공 응답 DTO 객체
      */
-    public static <T> ResponseDto<T> onSuccess(String code, String message, T data) {
-        return new ResponseDto<>(code, message, data);
+    public static <T> ResponseDto<T> onSuccessWithData(ResponseCode responseCode, T data) {
+        return new ResponseDto<>(responseCode.getCode(), responseCode.getMessage(), data);
+    }
+
+    /**
+     * 실패 응답 객체 생성
+     * @param responseCode {@link ResponseCode} 응답 코드 및 메시지
+     * @return 실패 응답 DTO 객체
+     */
+    public static ResponseDto<ResponseCode> onFailWithoutData(ResponseCode responseCode) {
+        return new ResponseDto<>(responseCode.getCode(), responseCode.getMessage());
     }
 
     /**
      * 실패 응답 객체 반환 메서드
-     * @param code {@link ResponseCode}의 응답 코드
-     * @param message {@link ResponseCode}의 응답 메시지
+     * @param responseCode {@link ResponseCode} 응답 코드 및 메시지
      * @param data 실패 응답에서 반환할 데이터
      * @return 실패 응답 DTO 객체
      */
-    public static <T> ResponseDto<T> onFail(String code, String message, T data) {
-        return new ResponseDto<>(code, message, data);
+    public static <T> ResponseDto<T> onFailWithData(ResponseCode responseCode, T data) {
+        return new ResponseDto<>(responseCode.getCode(), responseCode.getMessage(), data);
     }
+
 }

--- a/src/main/java/com/bside/sidefriends/common/response/ResponseDto.java
+++ b/src/main/java/com/bside/sidefriends/common/response/ResponseDto.java
@@ -1,0 +1,40 @@
+package com.bside.sidefriends.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResponseDto<T> {
+
+    private String code;
+    private String message;
+    private T data;
+
+    /**
+     * 성공 응답 객체 반환 메서드
+     * @param code {@link ResponseCode}의 응답 코드
+     * @param message {@link ResponseCode}의 응답 메시지
+     * @param data 성공 응답에서 반환할 데이터
+     * @return 성공 응답 DTO 객체
+     */
+    public static <T> ResponseDto<T> onSuccess(String code, String message, T data) {
+        return new ResponseDto<>(code, message, data);
+    }
+
+    /**
+     * 실패 응답 객체 반환 메서드
+     * @param code {@link ResponseCode}의 응답 코드
+     * @param message {@link ResponseCode}의 응답 메시지
+     * @param data 실패 응답에서 반환할 데이터
+     * @return 실패 응답 DTO 객체
+     */
+    public static <T> ResponseDto<T> onFail(String code, String message, T data) {
+        return new ResponseDto<>(code, message, data);
+    }
+}


### PR DESCRIPTION
### PR 목적
- 기능 구현

### PR 내용 요약
- 응답 코드 및 메시지 관리를 위한 `ResponseCode` Enum 클래스 생성
- 응답 객체 생성을 위한 `ResponseDto` 클래스 생성
- 명세에 맞는 응답 코드 및 메시지 정의 후, 반환하고 싶은 응답에 따라 `ResponseDto`의 정적 메서드를 선택하여 응답 객체 생성 후 컨트롤러에서 반환