### PR TITLE
feat: global exception handler common 패키지로 변경(sir/f/common)

### DIFF
--- a/src/main/java/com/bside/sidefriends/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bside/sidefriends/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,67 @@
+package com.bside.sidefriends.common.exception;
+
+import com.bside.sidefriends.common.response.ResponseCode;
+import com.bside.sidefriends.common.response.ResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import javax.validation.ConstraintViolationException;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Bad Request 에러: 클라이언트 입력값이 올바르지 않은 경우
+     * - 클라이언트 파라미터 자료형이 올바르지 않은 경우
+     * - 클라이언트 요청 바디 데이터가 정해진 형식에 맞지 않은 경우
+     * - 클라이언트 요청 바디 데이터가 올바른 json 데이터가 아닌 경우
+     */
+
+    // TODO: method argument not valid + constraint violation 둘 다 있는 경우? - IR
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<Map<String, String>>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        // validation을 통과하지 못한 필드
+        Map<String, String> fieldErrors = new HashMap<>();
+        e.getFieldErrors()
+                .forEach(error -> fieldErrors.put(error.getField(), error.getDefaultMessage()));
+
+
+        ResponseDto<Map<String, String>> responseDto
+                = ResponseDto.onFailWithData(ResponseCode.INVALID_INPUT, fieldErrors);
+
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ResponseDto<Map<String, String>>> handleConstraintViolationException(ConstraintViolationException e) {
+
+        // validation을 통과하지 못한 필드
+        Map<String, String> fieldErrors = new HashMap<>();
+        e.getConstraintViolations()
+                .forEach(error -> fieldErrors.put(error.getPropertyPath().toString(), error.getMessage()));
+
+        ResponseDto<Map<String, String>> responseDto
+                = ResponseDto.onFailWithData(ResponseCode.INVALID_INPUT, fieldErrors);
+
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ResponseDto<String>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+
+        ResponseDto<String> responseDto
+                = ResponseDto.onFailWithData(ResponseCode.INVALID_INPUT, e.getCause().getLocalizedMessage());
+
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    /**
+     * Busine
+     */
+}

--- a/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
+++ b/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 @Getter
 public enum ResponseCode {
 
+    // 공통(00-99)
+    INVALID_INPUT("001", "입력 값이 올바르지 않습니다."),
+
     // 로그인(101-150)
 
     // 회원(151-199)


### PR DESCRIPTION
### PR 목적
- 기능 구현

### PR 내용 요약
- `ExceptionHandler`에서 전역으로 Invalid Input 에러를 처리할 수 있도록 해당 에러 처리 관련 메서드를 common 패키지로 올림
- 전역으로 처리할 수 있는 Invalid Input에 대한 `ResponseCode` 추가
- 각 서비스별로 클라이언트의 올바르지 않은 입력값이 있을 때, 해당 응답 코드 및 common 패키지의 에러 처리 메서드를 이용해서 처리할 수 있을지 아닐지 결정 가능

