### PR TITLE
회원 엔티티에서의 대표펫 id 속성 타입 변경

### DIFF
--- a/src/main/java/com/bside/sidefriends/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/bside/sidefriends/pet/service/PetServiceImpl.java
@@ -161,7 +161,7 @@ public class PetServiceImpl implements PetService {
 
         return new FindAllPetResponseDto(
                 findUser.getUserId(),
-                Long.valueOf(findUser.getMainPetId()), // FIXME: mainPetId Long 변경
+                findUser.getMainPetId(),
                 petList.size(),
                 petList
         );
@@ -264,7 +264,7 @@ public class PetServiceImpl implements PetService {
 
         return new UpdateMainPetResponseDto(
                 findUser.getUserId(),
-                Long.valueOf(findUser.getMainPetId()), // FIXME: Long 타입 수정
+                findUser.getMainPetId(),
                 getPetInfo.apply(findPet)
         );
     }

--- a/src/main/java/com/bside/sidefriends/users/domain/User.java
+++ b/src/main/java/com/bside/sidefriends/users/domain/User.java
@@ -35,8 +35,7 @@ public class User {
     private String email;
 
     // 대표펫 id
-    // FIXME: Long 타입으로 바꿀 예정. IR.
-    private String mainPetId;
+    private Long mainPetId;
 
     // 회원 권한
     @Enumerated(EnumType.STRING)
@@ -138,8 +137,7 @@ public class User {
 
     // 대표펫 등록
     public void setMainPet(Long petId) {
-        // FIXME: Long 타입 변경. IR.
-        this.mainPetId = String.valueOf(petId);
+        this.mainPetId = petId;
     }
 
 

--- a/src/main/java/com/bside/sidefriends/users/service/dto/CreateUserResponseDto.java
+++ b/src/main/java/com/bside/sidefriends/users/service/dto/CreateUserResponseDto.java
@@ -21,8 +21,7 @@ public class CreateUserResponseDto {
 
     private User.Role role;
 
-    // FIXME: Long 타입 변경 필요. IR.
-    private String mainPetId;
+    private Long mainPetId;
 
     @URL
     private String userImageUrl;

--- a/src/main/java/com/bside/sidefriends/users/service/dto/FindUserByUserIdResponseDto.java
+++ b/src/main/java/com/bside/sidefriends/users/service/dto/FindUserByUserIdResponseDto.java
@@ -21,8 +21,7 @@ public class FindUserByUserIdResponseDto {
     @Email
     private String email;
 
-    // FIXME: Long 타입 변경 필요. IR.
-    private String mainPetId;
+    private Long mainPetId;
 
     private User.Role role;
 

--- a/src/main/java/com/bside/sidefriends/users/service/dto/ModifyUserResponseDto.java
+++ b/src/main/java/com/bside/sidefriends/users/service/dto/ModifyUserResponseDto.java
@@ -17,8 +17,7 @@ public class ModifyUserResponseDto {
     @NotNull
     private String name;
 
-    // FIXME: Long 타입 변경 필요. IR.
-    private String mainPetId;
+    private Long mainPetId;
 
     private User.Role role;
 


### PR DESCRIPTION
### PR 목적
- 기능 구현 변경

### PR 내용 요약
- 회원 엔티티 대표펫 id 속성(`mainPetId`)을 `String`에서 `Long` 타입으로 변경
- 펫 서비스, 회원 서비스 DTO에서 대표펫 id 관련 속성 타입 변경