### PR TITLE
퀵기록 Default 정보 생성 (메인펫->현재펫)

### DIFF
--- a/src/main/java/com/bside/sidefriends/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/bside/sidefriends/pet/service/PetServiceImpl.java
@@ -61,7 +61,7 @@ public class PetServiceImpl implements PetService {
                 // TODO: 펫 이미지
                 .build();
 
-        petRepository.save(petEntity);
+        Pet pet = petRepository.save(petEntity);
 
         // 사용자 펫 추가
         findUser.addPet(petEntity);
@@ -71,7 +71,7 @@ public class PetServiceImpl implements PetService {
         userRepository.save(findUser);
 
         // 펫 최초 생성 시, Default 퀵 정보 생성
-        quickService.createDefaultQuick(findUser);
+        quickService.createDefaultQuick(pet);
 
         return CreatePetResponseDto.builder()
                 .petId(petEntity.getPetId())

--- a/src/main/java/com/bside/sidefriends/quick/service/QuickService.java
+++ b/src/main/java/com/bside/sidefriends/quick/service/QuickService.java
@@ -1,5 +1,6 @@
 package com.bside.sidefriends.quick.service;
 
+import com.bside.sidefriends.pet.domain.Pet;
 import com.bside.sidefriends.quick.service.dto.*;
 import com.bside.sidefriends.users.domain.User;
 
@@ -9,10 +10,10 @@ public interface QuickService {
 
     /**
      * 퀵기록 최초 생성
-     * @param user @LoginUser
+     * @param pet 펫
      * @return {@link CreateQuickResponseDto} 퀵기록 생성 응답 DTO
      */
-    CreateQuickResponseDto createDefaultQuick(User user);
+    CreateQuickResponseDto createDefaultQuick(Pet pet);
 
 
     /**

--- a/src/main/java/com/bside/sidefriends/quick/service/QuickServiceImpl.java
+++ b/src/main/java/com/bside/sidefriends/quick/service/QuickServiceImpl.java
@@ -30,14 +30,10 @@ public class QuickServiceImpl implements QuickService {
     private final PetRepository petRepository;
 
     @Override
-    public CreateQuickResponseDto createDefaultQuick(User user) {
-        // Get Main Pet Info
-        Long petId = user.getMainPetId();
-        if (petId == null) throw new UserMainPetNotFoundException();
-
-        Pet pet = petRepository.findByPetId(petId).orElseThrow(PetNotFoundException::new);
+    public CreateQuickResponseDto createDefaultQuick(Pet pet) {
+        // Verify Pet Info
+        if (pet == null) throw new UserMainPetNotFoundException();
         if (pet.isDeactivated()) throw new PetDeactivatedException();
-
 
         // Get Quick Default Values
         List<QuickDefault> quickDefault = List.of(QuickDefault.values());


### PR DESCRIPTION
### PR 목적
- 기능 구현 변경

### PR 내용 요약
- 신규 펫 생성 시 Default 퀵기록 정보 생성에서
(변경 전) 메인 펫의 Default 퀵기록 생성
(변경 후) 현재 신규 생성 펫의 Default 퀵기록 생성