### PR TITLE
퀵기록 실행횟수 +1를 과거날짜에서도 수정 가능하도록 변경

### DIFF
--- a/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
+++ b/src/main/java/com/bside/sidefriends/common/response/ResponseCode.java
@@ -68,6 +68,7 @@ public enum ResponseCode {
     MODIFY_QUICK_COUNT_FAIL("310", "퀵 기록 실행 횟수 증가에 실패하였습니다."),
     QUICK_INVALID_INPUT("311","퀵 기록 서비스 입력 값이 올바르지 않습니다."),
     QUICK_NOT_FOUND("312","존재하지 않는 퀵 기록입니다."),
+    QUICK_COUNT_EXCEED("313","퀵 기록 실행횟수를 초과하였습니다."),
 
 
     // 체크리스트(401-450)

--- a/src/main/java/com/bside/sidefriends/quick/controller/QuickController.java
+++ b/src/main/java/com/bside/sidefriends/quick/controller/QuickController.java
@@ -7,6 +7,7 @@ import com.bside.sidefriends.quick.service.QuickService;
 import com.bside.sidefriends.quick.service.dto.*;
 import com.bside.sidefriends.security.auth.LoginUser;
 import com.bside.sidefriends.users.domain.User;
+import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
@@ -99,15 +100,18 @@ public class QuickController {
         return ResponseEntity.ok().body(responseDto);
     }
 
+    @ApiOperation(value = "changeQuickCount",
+            notes = "(2022-09-18) URI 변경. 변경전 : /quick/count/{quickId} 변경 후 : /quick/count/{quickId}/{date}")
     @ApiResponses({
             @ApiResponse(code=309, message = "퀵 기록 실행 횟수 증가에 성공하였습니다. (200)"),
             @ApiResponse(code=310, message = "퀵 기록 실행 횟수 증가에 실패하였습니다.")
     })
-    @PutMapping("/quick/count/{quickId}")
+    @PutMapping("/quick/count/{quickId}/{date}")
     ResponseEntity<ResponseDto<ChangeQuickCountResponseDto>> changeQuickCount (
-            @PathVariable("quickId") Long quickId) {
+            @PathVariable("quickId") Long quickId,
+            @PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 
-        ChangeQuickCountResponseDto changeQuickCountResponseDto = quickService.changeQuickCount(quickId);
+        ChangeQuickCountResponseDto changeQuickCountResponseDto = quickService.changeQuickCount(quickId, date);
 
         ResponseDto<ChangeQuickCountResponseDto> responseDto = ResponseDto.onSuccessWithData(
                 ResponseCode.MODIFY_QUICK_COUNT_SUCCESS, changeQuickCountResponseDto);

--- a/src/main/java/com/bside/sidefriends/quick/error/QuickExceptionHandler.java
+++ b/src/main/java/com/bside/sidefriends/quick/error/QuickExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.bside.sidefriends.quick.error;
+
+import com.bside.sidefriends.common.exception.BusinessException;
+import com.bside.sidefriends.common.response.ResponseCode;
+import com.bside.sidefriends.common.response.ResponseDto;
+import com.bside.sidefriends.quick.controller.QuickController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice(basePackageClasses = QuickController.class)
+public class QuickExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ResponseDto<?>> handleBusinessException(BusinessException e) {
+
+        String message = e.getMessage();
+        ResponseCode responseCode = e.getResponseCode();
+        final ResponseDto<?> responseDto;
+
+        if (message.equals(responseCode.getMessage())) {
+            responseDto = ResponseDto.onFailWithoutData(responseCode);
+        } else {
+
+            Map<String, String> errorData = new HashMap<>();
+            errorData.put("errorMessage", message);
+
+            responseDto = ResponseDto.onFailWithData(responseCode, errorData);
+        }
+
+        return ResponseEntity.ok().body(responseDto);
+    }
+}

--- a/src/main/java/com/bside/sidefriends/quick/error/exception/QuickCountExceedException.java
+++ b/src/main/java/com/bside/sidefriends/quick/error/exception/QuickCountExceedException.java
@@ -1,0 +1,10 @@
+package com.bside.sidefriends.quick.error.exception;
+
+import com.bside.sidefriends.common.exception.BusinessException;
+import com.bside.sidefriends.common.response.ResponseCode;
+
+public class QuickCountExceedException extends BusinessException {
+    public QuickCountExceedException(String message) {
+        super(message, ResponseCode.QUICK_COUNT_EXCEED);
+    }
+}

--- a/src/main/java/com/bside/sidefriends/quick/error/exception/QuickNotFoundException.java
+++ b/src/main/java/com/bside/sidefriends/quick/error/exception/QuickNotFoundException.java
@@ -1,0 +1,10 @@
+package com.bside.sidefriends.quick.error.exception;
+
+import com.bside.sidefriends.common.exception.BusinessException;
+import com.bside.sidefriends.common.response.ResponseCode;
+
+public class QuickNotFoundException extends BusinessException {
+    public QuickNotFoundException(String message) {
+        super(message, ResponseCode.QUICK_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/bside/sidefriends/quick/service/QuickService.java
+++ b/src/main/java/com/bside/sidefriends/quick/service/QuickService.java
@@ -47,6 +47,6 @@ public interface QuickService {
      * @param quickId 수정할 퀵 id
      * @return {@link ChangeQuickCountResponseDto} 퀵기록 실행횟수 변경 응답 DTO
      */
-    ChangeQuickCountResponseDto changeQuickCount(Long quickId);
+    ChangeQuickCountResponseDto changeQuickCount(Long quickId, LocalDate date);
     
 }

--- a/src/main/java/com/bside/sidefriends/quick/service/dto/ChangeQuickOrderRequestDto.java
+++ b/src/main/java/com/bside/sidefriends/quick/service/dto/ChangeQuickOrderRequestDto.java
@@ -3,6 +3,7 @@ package com.bside.sidefriends.quick.service.dto;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -13,6 +14,7 @@ public class ChangeQuickOrderRequestDto {
     private List<QuickOrder> quickOrderList;
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class QuickOrder {
         @ApiModelProperty(value = "퀵 Id", example = "1")


### PR DESCRIPTION
### PR 목적
- 기능 구현 변경
- 기능 Exception 처리

### PR 내용 요약
- 퀵기록 실행횟수 증가
(변경 전) 오늘 날짜에서만 퀵기록 실행횟수 +1 증가 가능
(변경 후) 오늘&과거 날짜에서도 퀵기록 실행횟수 +1 증가 가능

- 퀵기록 Exception 처리 추가 구현