### PR TITLE
펫 서비스 기능 구현 변경 및 오류 해결

### DIFF
--- a/src/main/java/com/bside/sidefriends/pet/controller/PetController.java
+++ b/src/main/java/com/bside/sidefriends/pet/controller/PetController.java
@@ -36,9 +36,7 @@ public class PetController {
     @PostMapping("/pets")
     public ResponseEntity<ResponseDto<CreatePetResponseDto>> createPet(@Valid @RequestBody CreatePetRequestDto createPetRequestDto) {
 
-        // TODO: username 관련 변경 필요
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String username = ((mainOAuth2User) principal).getUsername();
+        String username = getAuthenticatedUsername();
 
         CreatePetResponseDto createPetResponseDto = petService.createUserPet(username, createPetRequestDto);
 
@@ -51,9 +49,7 @@ public class PetController {
     @GetMapping("/pets")
     public ResponseEntity<ResponseDto<FindAllPetResponseDto>> findAllPets() {
 
-        // TODO: username 관련 변경 필요
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String username = ((mainOAuth2User) principal).getUsername();
+        String username = getAuthenticatedUsername();
 
         FindAllPetResponseDto findAllPetResponseDto = petService.findAllPets(username);
 
@@ -66,9 +62,7 @@ public class PetController {
     @PostMapping("/pets/{petId}/share")
     public ResponseEntity<ResponseDto<SharePetResponseDto>> sharePet(@PathVariable("petId") Long petId) {
 
-        // TODO: username 관련 변경 필요
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String username = ((mainOAuth2User) principal).getUsername();
+        String username = getAuthenticatedUsername();
 
         SharePetResponseDto sharePetResponseDto = petService.sharePet(username, petId);
 
@@ -80,9 +74,8 @@ public class PetController {
 
     @PutMapping("/pets/mainPet")
     public ResponseEntity<ResponseDto<UpdateMainPetResponseDto>> updateMainPet(@Valid @RequestBody UpdateMainPetRequestDto updateMainPetRequestDto) {
-        // TODO: username 관련 변경 필요
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String username = ((mainOAuth2User) principal).getUsername();
+
+        String username = getAuthenticatedUsername();
 
         UpdateMainPetResponseDto updateMainPetResponseDto = petService.updateMainPet(username, updateMainPetRequestDto);
 
@@ -157,6 +150,11 @@ public class PetController {
                 ResponseCode.P_DELETE_SUCCESS, deletePetResponseDto);
 
         return ResponseEntity.ok().body(responseDto);
+    }
+
+    private String getAuthenticatedUsername() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return ((mainOAuth2User) principal).getUsername();
     }
 
 }

--- a/src/main/java/com/bside/sidefriends/pet/domain/Pet.java
+++ b/src/main/java/com/bside/sidefriends/pet/domain/Pet.java
@@ -122,6 +122,12 @@ public class Pet {
     // 펫 삭제
     public void delete() {
         this.isDeleted = true;
+
+        // 유저 대표펫이었던 경우 대표펫 설정 해제
+        if (this.user.getMainPetId().equals(this.petId)) {
+            this.user.setMainPet(null);
+        }
+
     }
 
     // 사용자 펫 설정

--- a/src/main/java/com/bside/sidefriends/pet/domain/Pet.java
+++ b/src/main/java/com/bside/sidefriends/pet/domain/Pet.java
@@ -137,20 +137,12 @@ public class Pet {
 
     // 펫 가족 정보 반환
     public Long getFamilyIdInfo() {
-        if (this.family == null) {
-            return null;
-        } else {
-            return this.family.getFamilyId();
-        }
+        return this.family == null ? null : this.family.getFamilyId();
     }
 
     // 펫 이미지 url 반환
     public String getImageUrlInfo() {
-        if (this.petImage == null) {
-            return null;
-        } else {
-            return this.petImage.getImageUrl();
-        }
+        return this.petImage == null ? null : this.petImage.getImageUrl();
     }
 
 }

--- a/src/main/java/com/bside/sidefriends/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/bside/sidefriends/pet/service/PetServiceImpl.java
@@ -30,7 +30,6 @@ public class PetServiceImpl implements PetService {
 
     private final PetRepository petRepository;
 
-    // TODO: UserRepository, FamilyRepository 구현 변경 반영 필요
     private final UserRepository userRepository;
     private final FamilyRepository familyRepository;
 
@@ -64,9 +63,9 @@ public class PetServiceImpl implements PetService {
 
         Pet pet = petRepository.save(petEntity);
 
-        // 사용자 펫 추가
+        // 사용자 펫 추가 및 최초 등록 시 대표펫 설정
         findUser.addPet(petEntity);
-        if (findUser.getMainPetId() == null) { // 최초 등록 시 대표펫 설정
+        if (findUser.getMainPetId() == null) {
             findUser.setMainPet(petEntity.getPetId());
         }
         userRepository.save(findUser);
@@ -254,6 +253,8 @@ public class PetServiceImpl implements PetService {
 
         Pet findPet = petRepository.findByPetIdAndIsDeletedFalse(petId)
                 .orElseThrow(PetNotFoundException::new);
+
+        // TODO: 대표펫 삭제 시, 대표펫이 없는 경우 처리 방법 논의 필요. IR.
 
         findPet.delete();
         petRepository.save(findPet);

--- a/src/main/java/com/bside/sidefriends/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/bside/sidefriends/pet/service/PetServiceImpl.java
@@ -14,6 +14,7 @@ import com.bside.sidefriends.users.domain.User;
 import com.bside.sidefriends.users.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PetServiceImpl implements PetService {
 
     private final PetRepository petRepository;
@@ -37,6 +39,7 @@ public class PetServiceImpl implements PetService {
     // TODO: 전체적으로 사용자 소유 펫인지 확인 필요
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public CreatePetResponseDto createUserPet(String username, CreatePetRequestDto createPetRequestDto) {
 
         User findUser = userRepository.findByUsernameAndIsDeletedFalse(username)
@@ -56,7 +59,7 @@ public class PetServiceImpl implements PetService {
                 .shareScope(PetShareScope.PRIVATE) // 펫 생성 시 기본 개인 펫 설정
                 .isDeactivated(false) // 펫 생성 시 비활성화 여부 기본값 false
                 .isDeleted(false) // 펫 생성 시 삭제 여부 기본값 false
-                // TODO: 펫 이미지
+                .petImage(null)
                 .build();
 
         Pet pet = petRepository.save(petEntity);
@@ -81,10 +84,12 @@ public class PetServiceImpl implements PetService {
                 .age(petEntity.getAge())
                 .animalRegistrationNumber(petEntity.getAnimalRegistrationNumber())
                 .userId(petEntity.getUser().getUserId())
+                .petImageUrl(petEntity.getImageUrlInfo())
                 .build();
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public SharePetResponseDto sharePet(String username, Long petId) {
 
         User findUser = userRepository.findByUsernameAndIsDeletedFalse(username)
@@ -176,6 +181,7 @@ public class PetServiceImpl implements PetService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public ModifyPetResponseDto modifyPet(Long petId, ModifyPetRequestDto modifyPetRequestDto) {
 
         Pet findPet = petRepository.findByPetIdAndIsDeletedFalse(petId)
@@ -211,6 +217,7 @@ public class PetServiceImpl implements PetService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public DeactivatePetResponseDto deactivatePet(Long petId) {
 
         Pet findPet = petRepository.findByPetIdAndIsDeletedFalseAndIsDeactivatedFalse(petId)
@@ -226,6 +233,7 @@ public class PetServiceImpl implements PetService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public ActivatePetResponseDto activatePet(Long petId) {
 
         Pet findPet = petRepository.findByPetIdAndIsDeletedFalseAndIsDeactivatedTrue(petId)
@@ -241,6 +249,7 @@ public class PetServiceImpl implements PetService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public DeletePetResponseDto deletePet(Long petId) {
 
         Pet findPet = petRepository.findByPetIdAndIsDeletedFalse(petId)
@@ -256,6 +265,7 @@ public class PetServiceImpl implements PetService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public UpdateMainPetResponseDto updateMainPet(String username, UpdateMainPetRequestDto updateMainPetRequestDto) {
 
         Long petId = updateMainPetRequestDto.getMainPetId();

--- a/src/main/java/com/bside/sidefriends/pet/service/dto/CreatePetResponseDto.java
+++ b/src/main/java/com/bside/sidefriends/pet/service/dto/CreatePetResponseDto.java
@@ -54,5 +54,6 @@ public class CreatePetResponseDto {
     @ApiModelProperty(value = "반려동물 기록 중지 여부")
     private boolean isDeactivated;
 
+    @ApiModelProperty(value = "반려동물 프로필 이미지 url")
     private String petImageUrl;
 }


### PR DESCRIPTION
### PR 목적
- 기능 구현 변경

### PR 내용 요약
- 펫 삭제 시, 회원 대표펫 id 남아 있던 문제 해결
- 펫 서비스 및 컨트롤러 코드 리팩토링

### TODO
- 대표펫 삭제 시, 기존 회원의 대표펫 id가 null이 됨으로 인해 발생할 수 있는 문제에 대해 논의 필요